### PR TITLE
login: pam_misc is not needed

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ OBJD=obj
 RESD=res
 LANG=$(RESD)/lang
 INCL=-I$(SRCD) -I$(SUBD)/termbox-next/src -I$(SUBD)/inih
-LINK=-lm -lpam -lpam_misc
+LINK=-lm -lpam
 
 SRCS=$(SRCD)/main.c
 SRCS+=$(SRCD)/draw.c

--- a/src/login.c
+++ b/src/login.c
@@ -7,21 +7,21 @@
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
+#include <paths.h>  /* _PATH_MAILDIR */
 #include <signal.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <security/pam_appl.h>
-#include <security/pam_misc.h>
 
 #ifdef LY_SYSTEMD
 #define PAM_SYSTEMD
 #endif
-
-#include <security/pam_modules.h>
-#include <security/pam_modutil.h>
 
 int login_conv(int num_msg, const struct pam_message** msg,
 	struct pam_response** resp, void* appdata_ptr)


### PR DESCRIPTION
The pam_misc header and library, as well as the `pam_{modules,modutil}.h`,
are not needed.  Meanwhile add the necessary headers.

Builds fine on both Linux and DragonFly BSD.