### PR TITLE
Add location of Xresources for XDG Base Dir Spec

### DIFF
--- a/res/xsetup.sh
+++ b/res/xsetup.sh
@@ -90,6 +90,7 @@ elif [ -f /etc/X11/Xresources ]; then
   xrdb -merge /etc/X11/Xresources
 fi
 [ -f $HOME/.Xresources ] && xrdb -merge $HOME/.Xresources
+[ -f $XDG_CONFIG_HOME/X11/Xresources ] && xrdb -merge $XDG_CONFIG_HOME/X11/Xresources
 
 if [ -f "$USERXSESSION" ]; then
   . "$USERXSESSION"


### PR DESCRIPTION
Some of users want to keep their configs in unified folder. XDG Base Directory allows to do so, but there is no support of than in ly