### PR TITLE
asterisk_empty

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -9,6 +9,10 @@
 #asterisk = *
 #asterisk = o
 
+# print nor asterisk and password
+#asterisk_empty = true
+#asterisk_empty = false
+
 # background color id
 #bg = 0
 

--- a/src/config.c
+++ b/src/config.c
@@ -158,6 +158,7 @@ void config_load(const char *cfg_path)
 		{"animate", &config.animate, config_handle_bool},
 		{"animation", &config.animation, config_handle_u8},
 		{"asterisk", &config.asterisk, config_handle_char},
+                {"asterisk_empty", &config.asterisk_empty, config_handle_bool},
 		{"bg", &config.bg, config_handle_u8},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
@@ -264,6 +265,7 @@ void config_defaults()
 	config.animate = false;
 	config.animation = 0;
 	config.asterisk = '*';
+        config.asterisk_empty = false;
 	config.bg = 0;
 	config.blank_box = true;
 	config.blank_password = false;

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ struct config
 	bool animate;
 	u8 animation;
 	char asterisk;
+        bool asterisk_empty;
 	u8 bg;
 	bool blank_box;
 	bool blank_password;

--- a/src/draw.c
+++ b/src/draw.c
@@ -457,6 +457,7 @@ void position_input(
 {
 	u16 x = buf->box_x + config.margin_box_h + buf->labels_max_len + 1;
 	i32 len = buf->box_x + buf->box_width - config.margin_box_h - x;
+        i32 len_password = config.asterisk_empty ? 0 : len;
 
 	if (len < 0)
 	{
@@ -473,7 +474,7 @@ void position_input(
 
 	password->x = x;
 	password->y = buf->box_y + config.margin_box_v + 6;
-	password->visible_len = len;
+        password->visible_len = len_password;
 }
 
 static void doom_init(struct term_buf* buf)

--- a/src/draw.c
+++ b/src/draw.c
@@ -456,7 +456,7 @@ void position_input(
 	struct text* password)
 {
 	u16 x = buf->box_x + config.margin_box_h + buf->labels_max_len + 1;
-	i32 len = buf->box_x + buf->box_width - config.margin_box_h - x;
+        i32 len = buf->box_x + buf->box_width - config.margin_box_h - x;
         i32 len_password = config.asterisk_empty ? 0 : len;
 
 	if (len < 0)


### PR DESCRIPTION
Some login utilities don't write any output during the password input, so some users would (and I do) like ly to behave like them.