### PR TITLE
Use tb_poll_event instead of tb_peek_event

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -141,10 +141,16 @@ int main(int argc, char** argv)
 	struct term_buf buf;
 	uint8_t active_input = config.default_input;
 
-	(*input_handles[active_input])(input_structs[active_input], NULL);
 
 	// init drawing stuff
 	draw_init(&buf);
+
+	// draw_box and position_input are called because they need to be
+	// called before *input_handles[active_input] for the cursor to be
+	// positioned correctly
+	draw_box(&buf);
+	position_input(&buf, &desktop, &login, &password);
+	(*input_handles[active_input])(input_structs[active_input], NULL);
 
 	if (config.animate)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -174,6 +174,7 @@ int main(int argc, char** argv)
 		{
 			if (auth_fails < 10)
 			{
+				(*input_handles[active_input])(input_structs[active_input], NULL);
 				tb_clear();
 				animate(&buf);
 				draw_box(&buf);
@@ -195,7 +196,11 @@ int main(int argc, char** argv)
 			tb_present();
 		}
 
-		error = tb_peek_event(&event, config.min_refresh_delta);
+		if (config.animate) {
+			error = tb_peek_event(&event, config.min_refresh_delta);
+		} else {
+			error = tb_poll_event(&event);
+		}
 
 		if (error < 0)
 		{
@@ -221,6 +226,7 @@ int main(int argc, char** argv)
 				if (active_input > 0)
 				{
 					input_text_clear(input_structs[active_input]);
+					update = true;
 				}
 				break;
 			case TB_KEY_ARROW_UP:


### PR DESCRIPTION
Reduces CPU usage noticeably on my system, from 14% to nearly 0%. There is an issue where the cursor doesn't get positioned correctly on startup, this is because the cursor position is set in `input_handles[active_input]` on line 144 (which calls tb_set_cursor), before `position_inputs` has been called. It is not enough to just call `position_inputs` before line 144, because `position_inputs` itself requires that `draw_box` has been called,

There are other issues with this approach as well, if I can't find a solution for them it might be easier to just increase the default min_refresh_delta.