### PR TITLE
Changed active_input selection to be based on default config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -271,7 +271,7 @@ void config_defaults()
 	config.blank_box = true;
 	config.blank_password = false;
 	config.console_dev = strdup("/dev/console");
-	config.default_input = PASSWORD_INPUT;
+	config.default_input = LOGIN_INPUT;
 	config.fg = 9;
 	config.hide_borders = false;
 	config.input_len = 34;

--- a/src/main.c
+++ b/src/main.c
@@ -135,8 +135,16 @@ int main(int argc, char** argv)
 	// init visible elements
 	struct tb_event event;
 	struct term_buf buf;
-	uint8_t active_input = config.default_input;
-
+	
+	//Place the curser on the login field if there is no saved username, if there is, place the curser on the password field
+	uint8_t active_input;
+	if (login.text == login.end)
+	{
+		active_input = LOGIN_INPUT;
+	}
+	else{
+		active_input = PASSWORD_INPUT;
+	}
 
 	// init drawing stuff
 	draw_init(&buf);

--- a/src/main.c
+++ b/src/main.c
@@ -138,13 +138,13 @@ int main(int argc, char** argv)
 	
 	//Place the curser on the login field if there is no saved username, if there is, place the curser on the password field
 	uint8_t active_input;
-	if (login.text == login.end)
-	{
-		active_input = LOGIN_INPUT;
-	}
-	else{
-		active_input = PASSWORD_INPUT;
-	}
+        if (config.default_input == LOGIN_INPUT && login.text != login.end){
+        	active_input = PASSWORD_INPUT;
+        }
+        else{
+        	active_input = config.default_input;
+        }
+
 
 	// init drawing stuff
 	draw_init(&buf);


### PR DESCRIPTION
changed how the curser placement works to be based on if there is a saved username or not. if there is a saved user, it started on the password field, if there isn't a user name it will start on the username field. 