### PR TITLE
zsh environment fix

### DIFF
--- a/res/wsetup.sh
+++ b/res/wsetup.sh
@@ -24,6 +24,8 @@ case $SHELL in
     [ -d /etc/zsh ] && zdir=/etc/zsh || zdir=/etc
     zhome=${ZDOTDIR:-$HOME}
     # zshenv is always sourced automatically.
+    [ -f /etc/profile ] && . /etc/profile
+    [ -f $HOME/.profile ] && . $HOME/.profile
     [ -f $zdir/zprofile ] && . $zdir/zprofile
     [ -f $zhome/.zprofile ] && . $zhome/.zprofile
     [ -f $zdir/zlogin ] && . $zdir/zlogin

--- a/res/xsetup.sh
+++ b/res/xsetup.sh
@@ -24,6 +24,8 @@ case $SHELL in
     [ -d /etc/zsh ] && zdir=/etc/zsh || zdir=/etc
     zhome=${ZDOTDIR:-$HOME}
     # zshenv is always sourced automatically.
+    [ -f /etc/profile ] && . /etc/profile
+    [ -f $HOME/.profile ] && . $HOME/.profile
     [ -f $zdir/zprofile ] && . $zdir/zprofile
     [ -f $zhome/.zprofile ] && . $zhome/.zprofile
     [ -f $zdir/zlogin ] && . $zdir/zlogin


### PR DESCRIPTION
Resolves #407 

Since ZSH is a Bourne compatible shell, it should source both `/etc/profile` and `$HOME/.profile`