### PR TITLE
Fixes for the XDG Base Dirs implementation (#330)

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -302,7 +302,7 @@ void remove_utmp_entry(struct utmp *entry) {
 
 void xauth(const char* display_name, const char* shell, char* pwd)
 {
-	const char* xauth_file = ".lyxauth";
+	const char* xauth_file = "lyxauth";
 	char* xauth_dir = getenv("XDG_RUNTIME_DIR");
 	if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 	{
@@ -310,23 +310,15 @@ void xauth(const char* display_name, const char* shell, char* pwd)
 		if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 		{
 			xauth_dir = strdup(pwd);
-			strcat(xauth_dir, "/.config/ly");
+			strcat(xauth_dir, "/.config");
 			struct stat sb;
 			stat(xauth_dir, &sb);
 			if (!S_ISDIR(sb.st_mode))
 			{
 				xauth_dir = pwd;
-				// xauth_file is already assigned correctly
-			}
-			else
-			{
-				xauth_file = "lyxauth";
+				xauth_file = ".lyxauth";
 			}
 		}
-	}
-	else
-	{
-		xauth_file = "lyxauth";
 	}
 
 	// trim trailing slashes

--- a/src/login.c
+++ b/src/login.c
@@ -307,17 +307,34 @@ void xauth(const char* display_name, const char* shell, char* pwd)
 	if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 	{
 		xauth_dir = getenv("XDG_CONFIG_HOME");
+		struct stat sb;
 		if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 		{
 			xauth_dir = strdup(pwd);
 			strcat(xauth_dir, "/.config");
-			struct stat sb;
 			stat(xauth_dir, &sb);
-			if (!S_ISDIR(sb.st_mode))
+			if (S_ISDIR(sb.st_mode))
+			{
+				strcat(xauth_dir, "/ly");
+			}
+			else
 			{
 				xauth_dir = pwd;
 				xauth_file = ".lyxauth";
 			}
+		}
+		else
+		{
+			strcat(xauth_dir, "/ly");
+		}
+
+		// If .config/ly/ or XDG_CONFIG_HOME/ly/ doesn't exist and can't create the directory, use pwd
+		// Passing pwd beforehand is safe since stat will always evaluate false
+		stat(xauth_dir, &sb);
+		if (!S_ISDIR(sb.st_mode) && mkdir(xauth_dir, 0777) == -1)
+		{
+			xauth_dir = pwd;
+			xauth_file = ".lyxauth";
 		}
 	}
 

--- a/src/login.c
+++ b/src/login.c
@@ -306,11 +306,22 @@ void xauth(const char* display_name, const char* shell, char* pwd)
 	char* xauth_dir = getenv("XDG_RUNTIME_DIR");
 	if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 	{
-		xauth_dir = getenv("XDG_CONFIG_DIR");
+		xauth_dir = getenv("XDG_CONFIG_HOME");
 		if ((xauth_dir == NULL) || (*xauth_dir == '\0'))
 		{
-			xauth_dir = pwd;
-			xauth_file = "lyxauth";
+			xauth_dir = strdup(pwd);
+			strcat(xauth_dir, "/.config/ly");
+			struct stat sb;
+			stat(xauth_dir, &sb);
+			if (!S_ISDIR(sb.st_mode))
+			{
+				xauth_dir = pwd;
+				// xauth_file is already assigned correctly
+			}
+			else
+			{
+				xauth_file = "lyxauth";
+			}
 		}
 	}
 	else


### PR DESCRIPTION
Fixes errors/typos from #330 in order to better comply with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
* Renamed `XDG_CONFIG_DIR` to `XDG_CONFIG_HOME`
* added `$HOME/.config/` as fallback in case XDG_CONFIG_HOME is null, and PWD as last resort.
* Filename for the PWD fallback now has a dot (`.lyxauth` instead of `lyxauth`) just like the other dotfiles in $HOME

I made some tests and it works fine. I'm a complete noob in C so I'd appreciate if someone reviews the code.

Note we should probably not use XDG_CONFIG_HOME at all since `lyxauth` is far from a config file. Using /run/user/$UID/ or /tmp/ would probably be better, and then maybe use pwd as the *very* last resort just in case, i don't really know.