### PR TITLE
Re-add missing environment variables

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -618,8 +618,11 @@ void auth(
 		char vt[5];
 		snprintf(vt, 5, "vt%d", config.tty);
 
-		// set env
+		// set env (this clears the environment)
 		env_init(pwd);
+		// Re-add XDG environment variables from lines 508,509
+		env_xdg_session(desktop->display_server[desktop->cur]);
+		env_xdg(tty_id, desktop->list_simple[desktop->cur]);
 
 		if (dgn_catch())
 		{


### PR DESCRIPTION
Fixes #443 and #445 

The function `env_init` in line 622 clears the whole environment.
After adding the environment variables generated in lines 508 and 509 back in, everything works as it should.

I don't know enough about the rest of the code to know if the lines 508 and 509 can now be removed, so I didn't remove them yet.
I'd like some help from someone more experienced, if the variables are needed anywhere between the first setting (line 508) and the clearing (line 622).

You can see in #425 ([link to the specific line](https://github.com/fairyglade/ly/commit/09ee6293bdc38d40c210d6f0bd5f811f99329086#diff-07deafe51cfe4487a3ef6dcd084f1087335daa693bca590cf06653ec05618bf8L616))that the function `env_xdg` used to be called before `env_init`.