### PR TITLE
Tidy up runit service scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -100,7 +100,6 @@ installopenrc:
 
 installrunit:
 	@echo "installing runit service"
-	@install -dZ ${DESTDIR}/etc/sv/ly-runit-service
 	@install -DZ $(RESD)/ly-runit-service/* -t ${DESTDIR}/etc/sv/ly
 
 uninstall:
@@ -111,6 +110,7 @@ uninstall:
 	@rm -f ${DESTDIR}/usr/lib/systemd/system/ly.service
 	@rm -f ${DESTDIR}/etc/pam.d/ly
 	@rm -f ${DESTDIR}/etc/init.d/${NAME}
+	@rm -rf ${DESTDIR}/etc/sv/ly
 
 clean:
 	@echo "cleaning"

--- a/readme.md
+++ b/readme.md
@@ -120,13 +120,15 @@ $ make
 # ln -s /etc/sv/ly /var/service/
 ```
 
-Disable your existing display manager service if need be e.g.:
+By default, ly will run on tty2. To change the tty it must be set in `/etc/ly/config.ini` 
+
+You should as well disable your existing display manager service if needed, e.g.:
 
 ```
 # rm /var/service/lxdm
 ```
 
-If you are running on `tty2` (check your `/etc/ly/config.ini`) you can disable e.g. `agetty` running there:
+The agetty service for the tty console where you are running ly should be disabled. For instance, if you are running ly on tty2 (that's the default, check your `/etc/ly/config.ini`) you should disable the agetty-tty2 service like this:
 
 ```
 # rm /var/service/agetty-tty2

--- a/res/ly-runit-service/conf
+++ b/res/ly-runit-service/conf
@@ -8,7 +8,5 @@ fi
 BAUD_RATE=38400
 TERM_NAME=linux
 
-StandardInput=tty
-TTYPath=/dev/tty2
-TTYReset=yes
-TTYVHangup=yes
+auxtty=$(/bin/cat /etc/ly/config.ini 2>/dev/null 1| /bin/sed -n 's/\(^[[:space:]]*tty[[:space:]]*=[[:space:]]*\)\([[:digit:]][[:digit:]]*\)\(.*\)/\2/p')
+TTY=tty${auxtty:-2}

--- a/res/ly-runit-service/finish
+++ b/res/ly-runit-service/finish
@@ -1,3 +1,4 @@
 #!/bin/sh
-tty=${PWD##*-}
-exec utmpset -w $tty
+[ -r conf ] && . ./conf
+
+exec utmpset -w ${TTY}

--- a/res/ly-runit-service/run
+++ b/res/ly-runit-service/run
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-tty=${PWD##*-}
-
 [ -r conf ] && . ./conf
 
 if [ -x /sbin/getty -o -x /bin/getty ]; then
@@ -12,4 +10,4 @@ elif [ -x /sbin/agetty -o -x /bin/agetty ]; then
 	GETTY=agetty
 fi
 
-exec setsid ${GETTY} ${GETTY_ARGS} -nl /usr/bin/ly tty2 "${BAUD_RATE}" "${TERM_NAME}"
+exec setsid ${GETTY} ${GETTY_ARGS} -nl /usr/bin/ly "${TTY}" "${BAUD_RATE}" "${TERM_NAME}"


### PR DESCRIPTION
* Fix the script installation path (install everything only on /etc/sv/ly)

* Update the runit scripts to get the TTY value from the /etc/ly/config.ini file

* Update readme.md