### PR TITLE
Clocks

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -6,6 +6,8 @@
 # 1 -> CMatrix 
 #animation = 0
 
+# Whether a big clock should be displayed
+#clock = true
 
 # The character used to mask the password
 #asterisk = *

--- a/res/config.ini
+++ b/res/config.ini
@@ -6,8 +6,11 @@
 # 1 -> CMatrix 
 #animation = 0
 
-# Whether a big clock should be displayed
-#clock = true
+# format string for clock in top right corner (see strftime specification)
+#clock = %c
+
+# enable/disable big clock
+#bigclock = true
 
 # The character used to mask the password
 #asterisk = *

--- a/src/bigclock.h
+++ b/src/bigclock.h
@@ -3,11 +3,13 @@
 #define CLOCK_W 5
 #define CLOCK_H 5
 
-// #define X (char) 219 // block char
-// #define _ (char) 032 // space
-
-#define X 0x2593
-#define _ 0x0000
+#if defined(__linux__) || defined(__FreeBSD__)
+	#define X 0x2593
+	#define _ 0x0000
+#else
+	#define X '#'
+	#define _ 0
+#endif
 
 #if CLOCK_W == 5 && CLOCK_H == 5
 

--- a/src/bigclock.h
+++ b/src/bigclock.h
@@ -1,0 +1,144 @@
+#include <stdint.h>
+
+#define CLOCK_W 5
+#define CLOCK_H 5
+
+// #define X (char) 219 // block char
+// #define _ (char) 032 // space
+
+#define X 0x2593
+#define _ 0x0000
+
+#if CLOCK_W == 5 && CLOCK_H == 5
+
+uint32_t CLOCK_0[] = {
+	X,X,X,X,X,
+	X,X,_,X,X,
+	X,X,_,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_1[] = {
+	_,_,_,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X
+};
+
+uint32_t CLOCK_2[] = {
+	X,X,X,X,X,
+	_,_,_,X,X,
+	X,X,X,X,X,
+	X,X,_,_,_,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_3[] = {
+	X,X,X,X,X,
+	_,_,_,X,X,
+	X,X,X,X,X,
+	_,_,_,X,X,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_4[] = {
+	X,X,_,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X
+};
+
+uint32_t CLOCK_5[] = {
+	X,X,X,X,X,
+	X,X,_,_,_,
+	X,X,X,X,X,
+	_,_,_,X,X,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_6[] = {
+	X,X,X,X,X,
+	X,X,_,_,_,
+	X,X,X,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X,
+};
+
+uint32_t CLOCK_7[] = {
+	X,X,X,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X,
+	_,_,_,X,X
+};
+
+uint32_t CLOCK_8[] = {
+	X,X,X,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_9[] = {
+	X,X,X,X,X,
+	X,X,_,X,X,
+	X,X,X,X,X,
+	_,_,_,X,X,
+	X,X,X,X,X
+};
+
+uint32_t CLOCK_S[] = {
+	_,_,_,_,_,
+	_,_,X,_,_,
+	_,_,_,_,_,
+	_,_,X,_,_,
+	_,_,_,_,_
+};
+
+uint32_t CLOCK_E[] = {
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_
+};
+
+#endif
+
+#undef X
+#undef _
+
+static inline uint32_t* CLOCK_N(char c)
+{
+	switch(c)
+	{
+		case '0':
+			return CLOCK_0;
+		case '1':
+			return CLOCK_1;
+		case '2':
+			return CLOCK_2;
+		case '3':
+			return CLOCK_3;
+		case '4':
+			return CLOCK_4;
+		case '5':
+			return CLOCK_5;
+		case '6':
+			return CLOCK_6;
+		case '7':
+			return CLOCK_7;
+		case '8':
+			return CLOCK_8;
+		case '9':
+			return CLOCK_9;
+		case ':':
+			return CLOCK_S;
+		default:
+			return CLOCK_E;
+	}
+}

--- a/src/config.c
+++ b/src/config.c
@@ -163,6 +163,7 @@ void config_load(const char *cfg_path)
 		{"bg", &config.bg, config_handle_u8},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
+		{"clock", &config.clock, config_handle_bool},
 		{"console_dev", &config.console_dev, config_handle_str},
 		{"default_input", &config.default_input, config_handle_u8},
 		{"fg", &config.fg, config_handle_u8},

--- a/src/config.c
+++ b/src/config.c
@@ -164,6 +164,7 @@ void config_load(const char *cfg_path)
 		{"bigclock", &config.bigclock, config_handle_bool},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
+		{"clock", &config.clock, config_handle_str},
 		{"console_dev", &config.console_dev, config_handle_str},
 		{"default_input", &config.default_input, config_handle_u8},
 		{"fg", &config.fg, config_handle_u8},
@@ -273,6 +274,7 @@ void config_defaults()
 	config.bigclock = false;
 	config.blank_box = true;
 	config.blank_password = false;
+	config.clock = NULL;
 	config.console_dev = strdup("/dev/console");
 	config.default_input = LOGIN_INPUT;
 	config.fg = 9;
@@ -356,6 +358,7 @@ void lang_free()
 
 void config_free()
 {
+	free(config.clock);
 	free(config.console_dev);
 	free(config.lang);
 	free(config.mcookie_cmd);

--- a/src/config.c
+++ b/src/config.c
@@ -161,9 +161,9 @@ void config_load(const char *cfg_path)
 		{"animation", &config.animation, config_handle_u8},
 		{"asterisk", &config.asterisk, config_handle_char},
 		{"bg", &config.bg, config_handle_u8},
+		{"bigclock", &config.bigclock, config_handle_bool},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
-		{"clock", &config.clock, config_handle_bool},
 		{"console_dev", &config.console_dev, config_handle_str},
 		{"default_input", &config.default_input, config_handle_u8},
 		{"fg", &config.fg, config_handle_u8},
@@ -270,6 +270,7 @@ void config_defaults()
 	config.animation = 0;
 	config.asterisk = '*';
 	config.bg = 0;
+	config.bigclock = false;
 	config.blank_box = true;
 	config.blank_password = false;
 	config.console_dev = strdup("/dev/console");

--- a/src/config.h
+++ b/src/config.h
@@ -67,6 +67,7 @@ struct config
 	uint8_t bg;
 	bool blank_box;
 	bool blank_password;
+	bool clock;
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;

--- a/src/config.h
+++ b/src/config.h
@@ -65,9 +65,9 @@ struct config
 	uint8_t animation;
 	char asterisk;
 	uint8_t bg;
+	bool bigclock;
 	bool blank_box;
 	bool blank_password;
-	bool clock;
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;

--- a/src/config.h
+++ b/src/config.h
@@ -68,6 +68,7 @@ struct config
 	bool bigclock;
 	bool blank_box;
 	bool blank_password;
+	char* clock;
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;

--- a/src/draw.c
+++ b/src/draw.c
@@ -215,8 +215,11 @@ struct tb_cell* clock_cell(char c)
 	return cells;
 }
 
-void alpha_blit(struct tb_cell* buf, int x, int y, int w, int h, struct tb_cell* cells)
+void alpha_blit(struct tb_cell* buf, uint16_t x, uint16_t y, uint16_t w, uint16_t h, struct tb_cell* cells)
 {
+	if (x + w >= tb_width() || y + h >= tb_height())
+		return;
+
 	for (int i = 0; i < h; i++)
 	{
 		for (int j = 0; j < w; j++)
@@ -245,6 +248,8 @@ void draw_clock(struct term_buf* buf)
 		alpha_blit(tb_cell_buffer(), xo + i * (CLOCK_W + 1), yo, CLOCK_W, CLOCK_H, clockcell);
 		free(clockcell);
 	}
+
+	free(clockstr);
 }
 
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -265,6 +265,7 @@ void draw_clock(struct term_buf* buf)
 	tb_blit(buf->width - clockstrlen, 0, clockstrlen, 1, cells);
 
 	free(clockstr);
+	free(cells);
 }
 
 struct tb_cell* strn_cell(char* s, uint16_t len) // throws

--- a/src/draw.c
+++ b/src/draw.c
@@ -179,16 +179,17 @@ void draw_box(struct term_buf* buf)
 	}
 }
 
-char* bigclock_str()
+char* time_str(char* fmt, int maxlen)
 {
 	time_t timer;
-	char* buffer = malloc(6);
+	char* buffer = malloc(maxlen);
 	struct tm* tm_info;
 
 	timer = time(NULL);
 	tm_info = localtime(&timer);
 
-	strftime(buffer, 6, "%H:%M", tm_info);
+	if (strftime(buffer, maxlen, fmt, tm_info) == 0)
+		buffer[0] = '\0';
 	
 	return buffer;
 }
@@ -239,7 +240,7 @@ void draw_bigclock(struct term_buf* buf)
 	int xo = buf->box_x + buf->box_width / 2 - (5 * (CLOCK_W + 1)) / 2;
 	int yo = buf->box_y - CLOCK_H - 2;
 
-	char* clockstr = bigclock_str();
+	char* clockstr = time_str("%H:%M", 6);
 	struct tb_cell* clockcell;
 
 	for (int i = 0; i < 5; i++)
@@ -252,6 +253,19 @@ void draw_bigclock(struct term_buf* buf)
 	free(clockstr);
 }
 
+void draw_clock(struct term_buf* buf)
+{
+	if (config.clock == NULL || strlen(config.clock) == 0)
+		return;
+
+	char* clockstr = time_str(config.clock, 32);
+	int clockstrlen = strlen(clockstr);
+
+	struct tb_cell* cells = strn_cell(clockstr, clockstrlen);
+	tb_blit(buf->width - clockstrlen, 0, clockstrlen, 1, cells);
+
+	free(clockstr);
+}
 
 struct tb_cell* strn_cell(char* s, uint16_t len) // throws
 {

--- a/src/draw.c
+++ b/src/draw.c
@@ -237,8 +237,8 @@ void draw_bigclock(struct term_buf* buf)
 	if (!config.bigclock)
 		return;
 
-	int xo = buf->box_x + buf->box_width / 2 - (5 * (CLOCK_W + 1)) / 2;
-	int yo = buf->box_y - CLOCK_H - 2;
+	int xo = buf->width / 2 - (5 * (CLOCK_W + 1)) / 2;
+	int yo = (buf->height - buf->box_height) / 2 - CLOCK_H - 2;
 
 	char* clockstr = time_str("%H:%M", 6);
 	struct tb_cell* clockcell;

--- a/src/draw.c
+++ b/src/draw.c
@@ -5,6 +5,7 @@
 #include "utils.h"
 #include "config.h"
 #include "draw.h"
+#include "bigclock.h"
 
 #include <ctype.h>
 #include <fcntl.h>
@@ -14,7 +15,9 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <unistd.h>
+#include <time.h>
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
 	#include <sys/kbio.h>
@@ -175,6 +178,75 @@ void draw_box(struct term_buf* buf)
 		}
 	}
 }
+
+char* get_clock_string()
+{
+	time_t timer;
+	char* buffer = malloc(6);
+	struct tm* tm_info;
+
+	timer = time(NULL);
+	tm_info = localtime(&timer);
+
+	strftime(buffer, 6, "%H:%M", tm_info);
+	
+	return buffer;
+}
+
+extern inline uint32_t* CLOCK_N(char c);
+
+struct tb_cell* clock_cell(char c)
+{
+	struct tb_cell* cells = malloc(sizeof(struct tb_cell) * CLOCK_W * CLOCK_H);
+
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	if (config.animate && c == ':' && tv.tv_usec / 500000)
+		c = ' ';
+	uint32_t* clockchars = CLOCK_N(c);
+
+	for (int i = 0; i < CLOCK_W * CLOCK_H; i++)
+	{
+		cells[i].ch = clockchars[i];
+		cells[i].fg = config.fg;
+		cells[i].bg = config.bg;
+	}
+
+	return cells;
+}
+
+void alpha_blit(struct tb_cell* buf, int x, int y, int w, int h, struct tb_cell* cells)
+{
+	for (int i = 0; i < h; i++)
+	{
+		for (int j = 0; j < w; j++)
+		{
+			struct tb_cell cell = cells[i * w + j];
+			if (cell.ch)
+				buf[(y + i) * tb_width() + (x + j)] = cell;
+		}
+	}
+}
+
+void draw_clock(struct term_buf* buf)
+{
+	if (!config.clock)
+		return;
+
+	int xo = buf->box_x + buf->box_width / 2 - (5 * (CLOCK_W + 1)) / 2;
+	int yo = buf->box_y - CLOCK_H - 2;
+
+	char* clockstr = get_clock_string();
+	struct tb_cell* clockcell;
+
+	for (int i = 0; i < 5; i++)
+	{
+		clockcell = clock_cell(clockstr[i]);
+		alpha_blit(tb_cell_buffer(), xo + i * (CLOCK_W + 1), yo, CLOCK_W, CLOCK_H, clockcell);
+		free(clockcell);
+	}
+}
+
 
 struct tb_cell* strn_cell(char* s, uint16_t len) // throws
 {

--- a/src/draw.c
+++ b/src/draw.c
@@ -179,7 +179,7 @@ void draw_box(struct term_buf* buf)
 	}
 }
 
-char* get_clock_string()
+char* bigclock_str()
 {
 	time_t timer;
 	char* buffer = malloc(6);
@@ -231,15 +231,15 @@ void alpha_blit(struct tb_cell* buf, uint16_t x, uint16_t y, uint16_t w, uint16_
 	}
 }
 
-void draw_clock(struct term_buf* buf)
+void draw_bigclock(struct term_buf* buf)
 {
-	if (!config.clock)
+	if (!config.bigclock)
 		return;
 
 	int xo = buf->box_x + buf->box_width / 2 - (5 * (CLOCK_W + 1)) / 2;
 	int yo = buf->box_y - CLOCK_H - 2;
 
-	char* clockstr = get_clock_string();
+	char* clockstr = bigclock_str();
 	struct tb_cell* clockcell;
 
 	for (int i = 0; i < 5; i++)

--- a/src/draw.h
+++ b/src/draw.h
@@ -86,4 +86,6 @@ void animate_init(struct term_buf* buf);
 void animate(struct term_buf* buf);
 bool cascade(struct term_buf* buf, uint8_t* fails);
 
+void draw_clock(struct term_buf *buf);
+
 #endif

--- a/src/draw.h
+++ b/src/draw.h
@@ -86,6 +86,6 @@ void animate_init(struct term_buf* buf);
 void animate(struct term_buf* buf);
 bool cascade(struct term_buf* buf, uint8_t* fails);
 
-void draw_clock(struct term_buf *buf);
+void draw_bigclock(struct term_buf *buf);
 
 #endif

--- a/src/draw.h
+++ b/src/draw.h
@@ -87,5 +87,6 @@ void animate(struct term_buf* buf);
 bool cascade(struct term_buf* buf, uint8_t* fails);
 
 void draw_bigclock(struct term_buf *buf);
+void draw_clock(struct term_buf *buf);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -190,6 +190,7 @@ int main(int argc, char** argv)
 				animate(&buf);
 				draw_bigclock(&buf);
 				draw_box(&buf);
+				draw_clock(&buf);
 				draw_labels(&buf);
 				if(!config.hide_f1_commands)
 					draw_f_commands();
@@ -209,15 +210,26 @@ int main(int argc, char** argv)
 			tb_present();
 		}
 
-		if (config.animate) {
-			error = tb_peek_event(&event, config.min_refresh_delta);
-		} else if (config.bigclock) {
+		int timeout = -1;
+
+		if (config.animate)
+		{
+			timeout = config.min_refresh_delta;
+		}
+		else
+		{
 			struct timeval tv;
 			gettimeofday(&tv, NULL);
-			error = tb_peek_event(&event, (60 - tv.tv_sec % 60) * 1000 - tv.tv_usec / 1000);
-		} else {
-			error = tb_poll_event(&event);
+			if (config.bigclock)
+				timeout = (60 - tv.tv_sec % 60) * 1000 - tv.tv_usec / 1000 + 1;
+			if (config.clock)
+				timeout = 1000 - tv.tv_usec / 1000 + 1;
 		}
+
+		if (timeout == -1)
+			error = tb_poll_event(&event);
+		else
+			error = tb_peek_event(&event, timeout);
 
 		if (error < 0)
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -187,6 +187,7 @@ int main(int argc, char** argv)
 				(*input_handles[active_input])(input_structs[active_input], NULL);
 				tb_clear();
 				animate(&buf);
+				draw_clock(&buf);
 				draw_box(&buf);
 				draw_labels(&buf);
 				if(!config.hide_f1_commands)

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <stdlib.h>
 
@@ -210,6 +211,10 @@ int main(int argc, char** argv)
 
 		if (config.animate) {
 			error = tb_peek_event(&event, config.min_refresh_delta);
+		} else if (config.clock) {
+			struct timeval tv;
+			gettimeofday(&tv, NULL);
+			error = tb_peek_event(&event, (60 - tv.tv_sec % 60) * 1000 - tv.tv_usec / 1000);
 		} else {
 			error = tb_poll_event(&event);
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
 				(*input_handles[active_input])(input_structs[active_input], NULL);
 				tb_clear();
 				animate(&buf);
-				draw_clock(&buf);
+				draw_bigclock(&buf);
 				draw_box(&buf);
 				draw_labels(&buf);
 				if(!config.hide_f1_commands)
@@ -211,7 +211,7 @@ int main(int argc, char** argv)
 
 		if (config.animate) {
 			error = tb_peek_event(&event, config.min_refresh_delta);
-		} else if (config.clock) {
+		} else if (config.bigclock) {
 			struct timeval tv;
 			gettimeofday(&tv, NULL);
 			error = tb_peek_event(&event, (60 - tv.tv_sec % 60) * 1000 - tv.tv_usec / 1000);


### PR DESCRIPTION
This adds two ways to display the time:

- A nice big clock with 5x5 character digits right above the box
- Small formattable text in the top right corner

(screenshot below)

The small clock can be configured by a format string with the `clock` option and the big clock can be either turned on or off with the `bigclock` option.

If animations are disabled it will precisely repaint every full minute (for the big clock) or every second if the formattable clock is enabled.

I felt like this was missing in ly so I added these but still kept them disabled per default.

![screenshot_2022-11-19_00-03-44_524507576](https://user-images.githubusercontent.com/32263284/202817471-49558505-139b-4e1c-915c-6777b48c907b.png)