### PR TITLE
Fixed wrong argument in inputs.s input_desktop (issue #468)

### DIFF
--- a/src/inputs.c
+++ b/src/inputs.c
@@ -196,7 +196,7 @@ void input_desktop_add(
     target->list[target->cur] = name;
 
     int name_len = strlen(name);
-    char* name_simple = strdup(name_len);
+    char* name_simple = strdup(name);
 
     if (strstr(name_simple, " ") != NULL)
     {


### PR DESCRIPTION
Changed 

`char* name_simple = strdup(name_len);`
to
`char* name_simple = strdup(name);`

in inputs.c input_desktop
line 199