### PR TITLE
Fix: gnome-keyring and kwallet will be unlocked on login

### DIFF
--- a/res/pam.d/ly
+++ b/res/pam.d/ly
@@ -1,6 +1,10 @@
 #%PAM-1.0
 
 auth       include      login
+-auth      optional     pam_gnome_keyring.so
+-auth      optional     pam_kwallet5.so
 account    include      login
 password   include      login
 session    include      login
+-session   optional     pam_gnome_keyring.so auto_start
+-session   optional     pam_kwallet5.so auto_start


### PR DESCRIPTION
Needed to change the /etc/pam.d/ly file to get gnome-keyring to unlock on login, added kwallet as well for those who use that instead.

As the lines are prefixed with a - they will not throw any errors to the log if failed to load. That way it's a positive for those who use a keyring and not noticeable for those who don't. 

Fixes #331 