### PR TITLE
Add option to change enter key behaviour

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -75,6 +75,10 @@
 # File in which to save and load the default desktop and login
 #save_file = /etc/ly/save
 
+# If true, pressing enter will login regardless of current input box. If false, pressing enter will only login if the current
+# input box is for the password. Otherwise it will go to next input box.
+#enter_is_login = true
+
 
 # Remove power management command hints
 #hide_key_hints = false

--- a/src/config.c
+++ b/src/config.c
@@ -167,6 +167,7 @@ void config_load(const char *cfg_path)
 		{"clock", &config.clock, config_handle_str},
 		{"console_dev", &config.console_dev, config_handle_str},
 		{"default_input", &config.default_input, config_handle_u8},
+		{"enter_is_login", &config.enter_is_login, config_handle_bool},
 		{"fg", &config.fg, config_handle_u8},
 		{"hide_borders", &config.hide_borders, config_handle_bool},
 		{"hide_key_hints", &config.hide_key_hints, config_handle_bool},
@@ -279,6 +280,7 @@ void config_defaults()
 	config.clock = NULL;
 	config.console_dev = strdup("/dev/console");
 	config.default_input = LOGIN_INPUT;
+	config.enter_is_login = true;
 	config.fg = 9;
 	config.hide_borders = false;
 	config.hide_key_hints = false;

--- a/src/config.h
+++ b/src/config.h
@@ -71,6 +71,7 @@ struct config
 	char* clock;
 	char* console_dev;
 	uint8_t default_input;
+	bool enter_is_login;
 	uint8_t fg;
 	bool hide_borders;
 	bool hide_key_hints;

--- a/src/main.c
+++ b/src/main.c
@@ -313,35 +313,44 @@ int main(int argc, char** argv)
 				update = true;
 				break;
 			case TB_KEY_ENTER:
-				save(&desktop, &login);
-				auth(&desktop, &login, &password, &buf);
-				update = true;
-
-				if (dgn_catch())
+				if (config.enter_is_login || active_input == PASSWORD_INPUT) 
 				{
-					++auth_fails;
-					// move focus back to password input
-					active_input = PASSWORD_INPUT;
+					save(&desktop, &login);
+					auth(&desktop, &login, &password, &buf);
+					update = true;
 
-					if (dgn_output_code() != DGN_PAM)
+					if (dgn_catch())
 					{
-						buf.info_line = dgn_output_log();
+						++auth_fails;
+						// move focus back to password input
+						active_input = PASSWORD_INPUT;
+
+						if (dgn_output_code() != DGN_PAM)
+						{
+							buf.info_line = dgn_output_log();
+						}
+
+						if (config.blank_password)
+						{
+							input_text_clear(&password);
+						}
+
+						dgn_reset();
+					}
+					else
+					{
+						buf.info_line = lang.logout;
 					}
 
-					if (config.blank_password)
-					{
-						input_text_clear(&password);
-					}
-
-					dgn_reset();
+					load(&desktop, &login);
+					system("tput cnorm");
 				}
-				else
+				else 
 				{
-					buf.info_line = lang.logout;
+					++active_input;
+					update = true;
 				}
 
-				load(&desktop, &login);
-				system("tput cnorm");
 				break;
 			default:
 				(*input_handles[active_input])(


### PR DESCRIPTION
Currently, if you press the enter key after entering your username, it will try to authenticate, even if you haven't entered a password. This adds the option to change the default behaviour so that pressing the enter key while on the username field moves the cursor to the password field. By default the current behaviour is not changed.

I am not used to programming in C so I hope all the changes are acceptable :)
