### PR TITLE
Add configurable border color

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -43,6 +43,9 @@
 # Foreground color id
 #fg = 9
 
+# Border color id
+#border_fg = 9
+
 # Blank main box background
 # Setting to false will make it transparent
 #blank_box = true

--- a/src/config.c
+++ b/src/config.c
@@ -168,6 +168,7 @@ void config_load(const char *cfg_path)
 		{"console_dev", &config.console_dev, config_handle_str},
 		{"default_input", &config.default_input, config_handle_u8},
 		{"fg", &config.fg, config_handle_u8},
+		{"border_fg", &config.border_fg, config_handle_u8},
 		{"hide_borders", &config.hide_borders, config_handle_bool},
 		{"hide_key_hints", &config.hide_key_hints, config_handle_bool},
 		{"input_len", &config.input_len, config_handle_u8},
@@ -280,6 +281,7 @@ void config_defaults()
 	config.console_dev = strdup("/dev/console");
 	config.default_input = LOGIN_INPUT;
 	config.fg = 9;
+	config.border_fg = 9;
 	config.hide_borders = false;
 	config.hide_key_hints = false;
 	config.input_len = 34;

--- a/src/config.h
+++ b/src/config.h
@@ -72,6 +72,7 @@ struct config
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;
+	uint8_t border_fg;
 	bool hide_borders;
 	bool hide_key_hints;
 	uint8_t input_len;

--- a/src/draw.c
+++ b/src/draw.c
@@ -107,30 +107,30 @@ void draw_box(struct term_buf* buf)
 			box_x - 1,
 			box_y - 1,
 			buf->box_chars.left_up,
-			config.fg,
+			config.border_fg,
 			config.bg);
 		tb_change_cell(
 			box_x2,
 			box_y - 1,
 			buf->box_chars.right_up,
-			config.fg,
+			config.border_fg,
 			config.bg);
 		tb_change_cell(
 			box_x - 1,
 			box_y2,
 			buf->box_chars.left_down,
-			config.fg,
+			config.border_fg,
 			config.bg);
 		tb_change_cell(
 			box_x2,
 			box_y2,
 			buf->box_chars.right_down,
-			config.fg,
+			config.border_fg,
 			config.bg);
 
 		// top and bottom
-		struct tb_cell c1 = {buf->box_chars.top, config.fg, config.bg};
-		struct tb_cell c2 = {buf->box_chars.bot, config.fg, config.bg};
+		struct tb_cell c1 = {buf->box_chars.top, config.border_fg, config.bg};
+		struct tb_cell c2 = {buf->box_chars.bot, config.border_fg, config.bg};
 
 		for (uint16_t i = 0; i < buf->box_width; ++i)
 		{
@@ -164,7 +164,7 @@ void draw_box(struct term_buf* buf)
 
 	if (config.blank_box)
 	{
-		struct tb_cell blank = {' ', config.fg, config.bg};
+		struct tb_cell blank = {' ', config.border_fg, config.bg};
 
 		for (uint16_t i = 0; i < buf->box_height; ++i)
 		{


### PR DESCRIPTION
I added a new config variable that allows to change the border color.

This might be useful for modifying the style and was also requested by https://www.youtube.com/watch?v=JwudRbgLTNQ

![screenshot of ly with green border](https://github.com/fairyglade/ly/assets/10757520/27e63a77-d82a-4980-bcd6-31be251fe0cc)
The image uses the config `border_fg = 3`
https://github.com/fairyglade/ly/blob/ade056594c7781d5b62e2bebcfff2b48c504667d/res/config.ini#L40-L47

~~(Note: I am a bit confused about the indent of the file. In my editor as well as when I open the file in the github editor my lines are indented correctly, but not in the git diff)~~