### PR TITLE
Clear the screen before shutdown/reboot

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -353,6 +353,7 @@ int main(int argc, char** argv)
 		}
 	}
 
+	tb_clear();
 	// stop termbox
 	tb_shutdown();
 


### PR DESCRIPTION
On shutting down or reboot via F1 or F2 log messages are scratered all around the screen without any alignement etc.. This clears the screen before doing so. Note that this only clears the screen when using F1 and F2 keys and not after being logged in to a window manager and manually doing shutdown or reboot. I do not know much about display managers so if someone would merge this I would be glad if they add (if possible) ui clear when doing manual shutdown/reboot.