### PR TITLE
Add configurable animation color for CMatrix

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -43,6 +43,9 @@
 # Foreground color id
 #fg = 9
 
+# Animation color id (applies to CMatrix only)
+#animation_fg = 3
+
 # Blank main box background
 # Setting to false will make it transparent
 #blank_box = true

--- a/src/config.c
+++ b/src/config.c
@@ -159,6 +159,7 @@ void config_load(const char *cfg_path)
 	{
 		{"animate", &config.animate, config_handle_bool},
 		{"animation", &config.animation, config_handle_u8},
+		{"animation_fg", &config.animation_fg, config_handle_u8},
 		{"asterisk", &config.asterisk, config_handle_char},
 		{"bg", &config.bg, config_handle_u8},
 		{"bigclock", &config.bigclock, config_handle_bool},
@@ -271,6 +272,7 @@ void config_defaults()
 {
 	config.animate = false;
 	config.animation = 0;
+	config.animation_fg = 3;
 	config.asterisk = '*';
 	config.bg = 0;
 	config.bigclock = false;

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ struct config
 {
 	bool animate;
 	uint8_t animation;
+	uint8_t animation_fg;
 	char asterisk;
 	uint8_t bg;
 	bool bigclock;
@@ -72,7 +73,6 @@ struct config
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;
-	uint8_t animation_fg;
 	bool hide_borders;
 	bool hide_key_hints;
 	uint8_t input_len;

--- a/src/config.h
+++ b/src/config.h
@@ -72,6 +72,7 @@ struct config
 	char* console_dev;
 	uint8_t default_input;
 	uint8_t fg;
+	uint8_t animation_fg;
 	bool hide_borders;
 	bool hide_key_hints;
 	uint8_t input_len;

--- a/src/draw.c
+++ b/src/draw.c
@@ -922,8 +922,8 @@ static void matrix(struct term_buf* buf)
 		for (int i = 1; i <= buf->height; ++i)
 		{
 			uint32_t c;
-			int bg = TB_DEFAULT;
 			int fg = config.animation_fg;
+			int bg = TB_DEFAULT;
 
 			if (s->grid[i][j].val == -1 || s->grid[i][j].val == ' ')
 			{

--- a/src/draw.c
+++ b/src/draw.c
@@ -922,8 +922,8 @@ static void matrix(struct term_buf* buf)
 		for (int i = 1; i <= buf->height; ++i)
 		{
 			uint32_t c;
-			int fg = TB_GREEN;
 			int bg = TB_DEFAULT;
+			int fg = config.animation_fg;
 
 			if (s->grid[i][j].val == -1 || s->grid[i][j].val == ' ')
 			{


### PR DESCRIPTION
This PR adds the option to change the CMatrix foreground animation color using the config variable
`animation_fg`.
By default, it is set to `3` (green) which is the current default behavior.
The head of the lines is left at bold white.