### PR TITLE
Add a dinit service for ly

### DIFF
--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ installrunit:
 
 installdinit:
 	@echo "installing dinit service"
-	@install -CZ $(RESD)/ly-dinit -t ${DESTDIR}/etc/dinit.d/ly
+	@install -DZ $(RESD)/ly-dinit -t ${DESTDIR}/etc/dinit.d/ly
 	@echo "note: you will need to edit /etc/dinit.d/config/console.conf accordingly"
 
 uninstall:

--- a/makefile
+++ b/makefile
@@ -104,6 +104,11 @@ installrunit:
 	@echo "installing runit service"
 	@install -DZ $(RESD)/ly-runit-service/* -t ${DESTDIR}/etc/sv/ly
 
+installdinit:
+	@echo "installing dinit service"
+	@install -CZ $(RESD)/ly-dinit -t ${DESTDIR}/etc/dinit.d/ly
+	@echo "note: you will need to edit /etc/dinit.d/config/console.conf accordingly"
+
 uninstall:
 	@echo "uninstalling"
 	@rm -rf ${DESTDIR}/etc/ly

--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ installrunit:
 
 installdinit:
 	@echo "installing dinit service"
-	@install -DZ $(RESD)/ly-dinit -T ${DESTDIR}/etc/dinit.d/
+	@install -DZ $(RESD)/ly-dinit -T ${DESTDIR}/etc/dinit.d/ly
 	@echo "note: you will need to edit /etc/dinit.d/config/console.conf accordingly"
 
 uninstall:

--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ installrunit:
 
 installdinit:
 	@echo "installing dinit service"
-	@install -DZ $(RESD)/ly-dinit -t ${DESTDIR}/etc/dinit.d/ly
+	@install -DZ $(RESD)/ly-dinit -T ${DESTDIR}/etc/dinit.d/
 	@echo "note: you will need to edit /etc/dinit.d/config/console.conf accordingly"
 
 uninstall:

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,21 @@ The agetty service for the tty console where you are running ly should be disabl
 # rm /var/service/agetty-tty2
 ```
 
+### dinit
+
+```
+$ make
+# make install installdinit
+# dinitctl enable ly
+```
+
+In addition to the steps above, you will also have to keep a tty free within `/etc/dinit.d/config/console.conf`.
+~~To do that, change `ACTIVE_CONSOLES` so that the tty that ly should use in `/etc/ly/config.ini` is free.~~
+`ly` seems to ignore or something else is preventing the use of the `tty` option within `/etc/ly/config.ini` for any tty other than `tty1`.
+As such, `ACTIVE_CONSOLES` should be changed to keep tty1 free.
+For example by changing the default `/dev/tty[1-6]` to `/dev/tty[2-6]`.
+
+
 ## Arch Linux Installation
 You can install ly from the [`[extra]` repos](https://archlinux.org/packages/extra/x86_64/ly/):
 ```

--- a/readme.md
+++ b/readme.md
@@ -145,8 +145,9 @@ $ make
 
 In addition to the steps above, you will also have to keep a tty free within `/etc/dinit.d/config/console.conf`.
 ~~To do that, change `ACTIVE_CONSOLES` so that the tty that ly should use in `/etc/ly/config.ini` is free.~~
-`ly` seems to ignore or something else is preventing the use of the `tty` option within `/etc/ly/config.ini` for any tty other than `tty1`.
-As such, `ACTIVE_CONSOLES` should be changed to keep tty1 free.
+
+It seems that the `tty` option within `/etc/ly/config.ini` is ignored for any tty other than `tty1`.
+As such, `ACTIVE_CONSOLES` should be changed to keep tty1 free for use by `ly`.
 For example by changing the default `/dev/tty[1-6]` to `/dev/tty[2-6]`.
 
 

--- a/res/ly-dinit
+++ b/res/ly-dinit
@@ -1,0 +1,9 @@
+type            = process
+restart         = true
+smooth-recovery = true
+# note: /usr/bin/ly-dm when installing from pacman on artix, /usr/bin/ly when building from source
+command         = /usr/bin/ly
+depends-on      = loginready
+termsignal      = HUP
+# ly needs access to the console while loginready already occupies it
+options         = shares-console


### PR DESCRIPTION
Adds a dinit service file and an option to install it (`installdinit`), as well as additional instructions on how to configure the console configuration of dinit (`/etc/dinit.d/config/console.conf`).

#528
#190