### PR TITLE
Fix animation not displaying after window change

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -776,17 +776,18 @@ static void doom(struct term_buf* term_buf)
 		{0x2588, 8, 4}, // white
 	};
 
+	if ((term_buf->width != term_buf->init_width) || (term_buf->height != term_buf->init_height))
+	{
+		doom_free(term_buf);
+		doom_init(term_buf);
+	}
+
 	uint16_t src;
 	uint16_t random;
 	uint16_t dst;
 
 	uint16_t w = term_buf->init_width;
 	uint8_t* tmp = term_buf->astate.doom->buf;
-
-	if ((term_buf->width != term_buf->init_width) || (term_buf->height != term_buf->init_height))
-	{
-		return;
-	}
 
 	struct tb_cell* buf = tb_cell_buffer();
 
@@ -823,6 +824,12 @@ static void doom(struct term_buf* term_buf)
 // Adapted from cmatrix
 static void matrix(struct term_buf* buf)
 {
+	if ((buf->width != buf->init_width) || (buf->height != buf->init_height))
+	{
+		matrix_free(buf);
+		matrix_init(buf);
+	}
+
 	static int frame = 3;
 	const int frame_delay = 8;
 	static int count = 0;
@@ -834,11 +841,6 @@ static void matrix(struct term_buf* buf)
 	const int randnum = 123 - randmin;
 	// Chars change mid-scroll
 	const bool changes = true;
-
-	if ((buf->width != buf->init_width) || (buf->height != buf->init_height))
-	{
-		return;
-	}
 
 	count += 1;
 	if (count > frame_delay)

--- a/src/login.c
+++ b/src/login.c
@@ -501,8 +501,8 @@ void auth(
 {
 	int ok;
 
-    char tty_id [3];
-    snprintf(tty_id, 3, "%d", config.tty);
+    char tty_id [4];
+    snprintf(tty_id, 4, "%d", config.tty);
 
     // Add XDG environment variables
     env_xdg_session(desktop->display_server[desktop->cur]);
@@ -615,8 +615,8 @@ void auth(
 		}
 
 		// get a display
-		char vt[5];
-		snprintf(vt, 5, "vt%d", config.tty);
+		char vt[6];
+		snprintf(vt, 6, "vt%d", config.tty);
 
 		// set env (this clears the environment)
 		env_init(pwd);
@@ -712,4 +712,3 @@ void auth(
 		pam_diagnose(ok, buf);
 	}
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -129,7 +129,11 @@ int main(int argc, char** argv)
 	load(&desktop, &login);
 
 	// start termbox
-	tb_init();
+	if (tb_init() != 0)
+	{
+		fprintf(stderr, "Failed to initialize termbox.\n");
+		abort();
+	}
 	tb_select_output_mode(TB_OUTPUT_NORMAL);
 	tb_clear();
 


### PR DESCRIPTION
Volatile window changes on startup seem to cause the animation to not show up sometimes.
Simply restarting the animation when the termbox window changed, mitigates it.

Should fix #556 and #529.