### PR TITLE
Added Bigclock configuration

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -12,6 +12,9 @@
 # enable/disable big clock
 #bigclock = true
 
+# Big clock formatting (see strftime specification) [allowed symbols 1-9,-,:]
+#bigclock_format = %c
+
 # The character used to mask the password
 #asterisk = *
 

--- a/res/config.ini
+++ b/res/config.ini
@@ -10,7 +10,7 @@
 #clock = %c
 
 # enable/disable big clock
-#bigclock = true
+#bigclock = false
 
 # Big clock formatting (see strftime specification) [allowed symbols 1-9,-,:]
 #bigclock_format = %H:%M

--- a/res/config.ini
+++ b/res/config.ini
@@ -13,7 +13,7 @@
 #bigclock = true
 
 # Big clock formatting (see strftime specification) [allowed symbols 1-9,-,:]
-#bigclock_format = %c
+#bigclock_format = %H:%M
 
 # The character used to mask the password
 #asterisk = *

--- a/res/config.ini
+++ b/res/config.ini
@@ -15,6 +15,9 @@
 # Big clock formatting (see strftime specification) [allowed symbols 1-9,-,:]
 #bigclock_format = %H:%M
 
+# Unicode Number of Big Block character. Supports UTF-16(Example █ = U+2588 = 0x2588 = 9608)
+#bigclock_char = 9608
+
 # The character used to mask the password
 #asterisk = *
 

--- a/src/bigclock.h
+++ b/src/bigclock.h
@@ -3,13 +3,8 @@
 #define CLOCK_W 5
 #define CLOCK_H 5
 
-#if defined(__linux__) || defined(__FreeBSD__)
-	#define X 0x2593
-	#define _ 0x0000
-#else
-	#define X '#'
-	#define _ 0
-#endif
+#define X '.'
+#define _ 0
 
 #if CLOCK_W == 5 && CLOCK_H == 5
 
@@ -121,6 +116,9 @@ uint32_t CLOCK_D[] = {
 
 #undef X
 #undef _
+
+// I wish these were in a premade dictionary... Writing this felt like hell
+uint32_t* CLOCK_CHARS[] = {CLOCK_0,CLOCK_1,CLOCK_2,CLOCK_3,CLOCK_4,CLOCK_5,CLOCK_6,CLOCK_7,CLOCK_8,CLOCK_9,CLOCK_S,CLOCK_E,CLOCK_D}; 
 
 static inline uint32_t* CLOCK_N(char c)
 {

--- a/src/bigclock.h
+++ b/src/bigclock.h
@@ -109,6 +109,14 @@ uint32_t CLOCK_E[] = {
 	_,_,_,_,_
 };
 
+uint32_t CLOCK_D[] = {
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,X,X,X,_,
+	_,_,_,_,_,
+	_,_,_,_,_
+};
+
 #endif
 
 #undef X
@@ -140,6 +148,8 @@ static inline uint32_t* CLOCK_N(char c)
 			return CLOCK_9;
 		case ':':
 			return CLOCK_S;
+    case '-':
+      return CLOCK_D;
 		default:
 			return CLOCK_E;
 	}

--- a/src/config.c
+++ b/src/config.c
@@ -162,6 +162,7 @@ void config_load(const char *cfg_path)
 		{"asterisk", &config.asterisk, config_handle_char},
 		{"bg", &config.bg, config_handle_u8},
 		{"bigclock", &config.bigclock, config_handle_bool},
+    {"bigclock_format", &config.bigclock_format, config_handle_str},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
 		{"clock", &config.clock, config_handle_str},

--- a/src/config.c
+++ b/src/config.c
@@ -162,6 +162,7 @@ void config_load(const char *cfg_path)
 		{"asterisk", &config.asterisk, config_handle_char},
 		{"bg", &config.bg, config_handle_u8},
 		{"bigclock", &config.bigclock, config_handle_bool},
+    {"bigclock_char", &config.bigclock_char, config_handle_u16},
     {"bigclock_format", &config.bigclock_format, config_handle_str},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
@@ -276,6 +277,7 @@ void config_defaults()
 	config.bg = 0;
 	config.bigclock = false;
   config.bigclock_format = NULL;
+  config.bigclock_char = 0x2588;
 	config.blank_box = true;
 	config.blank_password = false;
 	config.clock = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -275,6 +275,7 @@ void config_defaults()
 	config.asterisk = '*';
 	config.bg = 0;
 	config.bigclock = false;
+  config.bigclock_format = NULL;
 	config.blank_box = true;
 	config.blank_password = false;
 	config.clock = NULL;
@@ -365,6 +366,7 @@ void lang_free()
 void config_free()
 {
 	free(config.clock);
+  free(config.bigclock_format);
 	free(config.console_dev);
 	free(config.lang);
 	free(config.mcookie_cmd);

--- a/src/config.c
+++ b/src/config.c
@@ -275,7 +275,7 @@ void config_defaults()
 	config.asterisk = '*';
 	config.bg = 0;
 	config.bigclock = false;
-  config.bigclock_format = "%H:%M";
+  config.bigclock_format = NULL;
 	config.blank_box = true;
 	config.blank_password = false;
 	config.clock = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -275,7 +275,7 @@ void config_defaults()
 	config.asterisk = '*';
 	config.bg = 0;
 	config.bigclock = false;
-  config.bigclock_format = NULL;
+  config.bigclock_format = "%H:%M";
 	config.blank_box = true;
 	config.blank_password = false;
 	config.clock = NULL;

--- a/src/config.h
+++ b/src/config.h
@@ -67,6 +67,7 @@ struct config
 	uint8_t bg;
 	bool bigclock;
   char* bigclock_format;
+  uint32_t bigclock_char;
 	bool blank_box;
 	bool blank_password;
 	char* clock;

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,7 @@ struct config
 	char asterisk;
 	uint8_t bg;
 	bool bigclock;
+  char* bigclock_format;
 	bool blank_box;
 	bool blank_password;
 	char* clock;

--- a/src/draw.c
+++ b/src/draw.c
@@ -3,7 +3,7 @@
 
 #include "inputs.h"
 #include "utils.h"
-#include "config.h"
+#include "config.h" 
 #include "draw.h"
 #include "bigclock.h"
 
@@ -70,6 +70,7 @@ void draw_init(struct term_buf* buf)
 	buf->box_chars.left = '|';
 	buf->box_chars.right = '|';
 #endif
+  bigclock_character_change();  
 }
 
 static void doom_free(struct term_buf* buf);
@@ -89,6 +90,20 @@ void draw_free(struct term_buf* buf)
 				break;
 		}
 	}
+}
+
+void bigclock_character_change(){
+  for(int i = 0; i < sizeof(CLOCK_CHARS)/sizeof(CLOCK_CHARS[0]);i++){ 
+    uint32_t* curent_clock_char = CLOCK_CHARS[i];
+
+    for(int j = 0;j < 25;j++){
+      uint32_t current_char = curent_clock_char[j];
+      
+      if(current_char!=0){
+        curent_clock_char[j] = config.bigclock_char;
+      }
+    }
+  } 
 }
 
 void draw_box(struct term_buf* buf)

--- a/src/draw.c
+++ b/src/draw.c
@@ -240,11 +240,15 @@ void alpha_blit(struct tb_cell* buf, uint16_t x, uint16_t y, uint16_t w, uint16_
 
 void draw_bigclock(struct term_buf* buf)
 {
-	if (!config.bigclock || strlen(config.bigclock_format)==0)
+	if (!config.bigclock)
     {
         return;
     }
-   	
+  
+  if(config.bigclock_format==NULL){
+    config.bigclock_format = "%H:%M";
+  }
+  
   int bigclocklength = strlen(config.bigclock_format);
   int xo = (buf->width / 2) - bigclocklength * (CLOCK_W+1) / 2;
 	int yo = (buf->height - buf->box_height) / 2 - CLOCK_H - 2;

--- a/src/draw.c
+++ b/src/draw.c
@@ -240,11 +240,11 @@ void alpha_blit(struct tb_cell* buf, uint16_t x, uint16_t y, uint16_t w, uint16_
 
 void draw_bigclock(struct term_buf* buf)
 {
-	if (!config.bigclock)
+  uint32_t bigclocklength = strlen(config.bigclock_format);
+	if (!config.bigclock || bigclocklength == 0)
     {
         return;
     }
-  uint32_t bigclocklength = strlen(config.bigclock_format);
 	
   int xo = (buf->width / 2) - bigclocklength * (CLOCK_W+1) / 2;
 	int yo = (buf->height - buf->box_height) / 2 - CLOCK_H - 2;

--- a/src/draw.c
+++ b/src/draw.c
@@ -240,12 +240,12 @@ void alpha_blit(struct tb_cell* buf, uint16_t x, uint16_t y, uint16_t w, uint16_
 
 void draw_bigclock(struct term_buf* buf)
 {
-  uint32_t bigclocklength = strlen(config.bigclock_format);
-	if (!config.bigclock || bigclocklength == 0)
+	if (!config.bigclock || strlen(config.bigclock_format)==0)
     {
         return;
     }
-	
+   	
+  int bigclocklength = strlen(config.bigclock_format);
   int xo = (buf->width / 2) - bigclocklength * (CLOCK_W+1) / 2;
 	int yo = (buf->height - buf->box_height) / 2 - CLOCK_H - 2;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -244,14 +244,15 @@ void draw_bigclock(struct term_buf* buf)
     {
         return;
     }
-
-	int xo = buf->width / 2 - (5 * (CLOCK_W + 1)) / 2;
+  uint32_t bigclocklength = strlen(config.bigclock_format);
+	
+  int xo = (buf->width / 2) - bigclocklength * (CLOCK_W+1) / 2;
 	int yo = (buf->height - buf->box_height) / 2 - CLOCK_H - 2;
 
-	char* clockstr = time_str("%H:%M", 6);
+	char* clockstr = time_str(config.bigclock_format, 32);
 	struct tb_cell* clockcell;
 
-	for (int i = 0; i < 5; i++)
+	for (int i = 0; i < bigclocklength; i++)
 	{
 		clockcell = clock_cell(clockstr[i]);
 		alpha_blit(tb_cell_buffer(), xo + i * (CLOCK_W + 1), yo, CLOCK_W, CLOCK_H, clockcell);

--- a/src/draw.h
+++ b/src/draw.h
@@ -88,5 +88,6 @@ bool cascade(struct term_buf* buf, uint8_t* fails);
 
 void draw_bigclock(struct term_buf *buf);
 void draw_clock(struct term_buf *buf);
+void bigclock_character_change();
 
 #endif


### PR DESCRIPTION
## Big clock configuration
Just like clock, big clock can be configured. Added new config.ini entry called "bigclock_format".

## Added - as bigclock symbol
We gotta re-write that bigclock.h file. Whatever is being done there right now is downright cursed.