### PR TITLE
Add support for animations after terminal is resized.

### DIFF
--- a/src/draw.h
+++ b/src/draw.h
@@ -28,6 +28,8 @@ struct matrix_dot
 struct matrix_state
 {
 	struct matrix_dot** grid;
+	uint16_t grid_width;
+	uint16_t grid_height;
 	int* length;
 	int* spaces;
 	int* updates;
@@ -36,6 +38,8 @@ struct matrix_state
 struct doom_state
 {
 	uint8_t* buf;
+	uint16_t buffer_width;
+	uint16_t buffer_height;
 };
 
 union anim_state
@@ -48,8 +52,6 @@ struct term_buf
 {
 	uint16_t width;
 	uint16_t height;
-	uint16_t init_width;
-	uint16_t init_height;
 
 	struct box box_chars;
 	char* info_line;


### PR DESCRIPTION
## Issue
On my laptop, the TTYs will occasionally have an incorrect initial size. This causes animations to only appear  ~50% of the time.
## Recreating the issue
This issue can easily be simulated by running the `make run` target and resizing the terminal window.
## Current behavior
- If the host terminal is resized, `ly` will appear as if no animation is enabled. 
- If the terminal height is `3` and the `matrix` animation is enabled, `ly` will crash.
## New behavior
- The enabled animation will be restarted/reinitialized when the terminal is resized.
- `ly` won't crash when the terminal height is `3` and the `matrix` animation is enabled.