### PR TITLE
Fix matrix animation crash when terminal height is 3

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -709,6 +709,11 @@ static void matrix_init(struct term_buf* buf)
 		dgn_throw(DGN_ALLOC);
 	}
 
+	if(buf->height <= 3)
+	{
+		return;
+	}
+
 	// Initialize grid
 	for (int i = 0; i <= buf->height; ++i)
 	{
@@ -836,6 +841,11 @@ static void matrix(struct term_buf* buf)
 	const bool changes = true;
 
 	if ((buf->width != buf->init_width) || (buf->height != buf->init_height))
+	{
+		return;
+	}
+
+	if(buf->height <= 3)
 	{
 		return;
 	}


### PR DESCRIPTION
## Current behavior
If the `matrix` animation is enabled and the terminal height is 3, the modulus operation on draw.c::724 will raise an Arithmetic Exception. This will cause `ly` to crash.
```
724 |  s->length[j] = (int) rand() % (buf->height - 3) + 3;
                                   ^^^^^^^^^^^^^^^^^^^
```
The same thing could happen on line 861:
```
861 | s->length[j] = (int) rand() % (buf->height - 3) + 3;
                                  ^^^^^^^^^^^^^^^^^^^
```
## New behavior
Ly will not attempt to display the matrix animation if `buf->height <= 3`.