### PR TITLE
Fix warnings and possible overflows in various buffers

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -501,8 +501,8 @@ void auth(
 {
 	int ok;
 
-    char tty_id [3];
-    snprintf(tty_id, 3, "%d", config.tty);
+    char tty_id [4];
+    snprintf(tty_id, 4, "%d", config.tty);
 
     // Add XDG environment variables
     env_xdg_session(desktop->display_server[desktop->cur]);

--- a/src/login.c
+++ b/src/login.c
@@ -615,8 +615,8 @@ void auth(
 		}
 
 		// get a display
-		char vt[5];
-		snprintf(vt, 5, "vt%d", config.tty);
+		char vt[6];
+		snprintf(vt, 6, "vt%d", config.tty);
 
 		// set env (this clears the environment)
 		env_init(pwd);


### PR DESCRIPTION
Hi fairyglade.

This patchset simply allows for the worst-case scenario when snprintfing to buffers, which also removes a warning during compilation.

C strings use a null terminating character, `'\0`, to mark the end of a string for functions that support string inputs without a given size. So, they are always 1 byte bigger than the string that they hold.