### PR TITLE
Added Farsi digits for bigclock

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -12,6 +12,11 @@
 # enable/disable big clock
 #bigclock = true
 
+# changes bigclock language
+# 0 -> English (default)
+# 1 -> Farsi
+#bigclock_lang = 0
+
 # The character used to mask the password
 #asterisk = *
 

--- a/src/bigclock.h
+++ b/src/bigclock.h
@@ -109,13 +109,141 @@ uint32_t CLOCK_E[] = {
 	_,_,_,_,_
 };
 
+//Farsi digits
+
+uint32_t CLOCK_1_0[] = {
+	_,_,_,_,_,
+	_,_,X,_,_,
+	_,X,_,X,_,
+	_,_,X,_,_,
+	_,_,_,_,_
+};
+
+uint32_t CLOCK_1_1[] = {
+	_,_,X,_,_,
+	_,_,X,_,_,
+	_,_,X,_,_,
+	_,_,X,_,_,
+	_,_,X,_,_
+};
+
+uint32_t CLOCK_1_2[] = {
+	_,X,_,X,_,
+	_,X,X,X,_,
+	_,X,_,_,_,
+	_,X,_,_,_,
+	_,X,_,_,_
+};
+
+uint32_t CLOCK_1_3[] = {
+	X,_,X,_,X,
+	X,X,X,X,X,
+	X,_,_,_,_,
+	X,_,_,_,_,
+	X,_,_,_,_
+};
+
+uint32_t CLOCK_1_4[] = {
+	_,X,_,X,X,
+	_,X,_,X,_,
+	_,X,X,X,X,
+	_,X,_,_,_,
+	_,X,_,_,_
+};
+
+uint32_t CLOCK_1_5[] = {
+	_,_,X,_,_,
+	_,X,_,X,_,
+	X,_,_,_,X,
+	X,_,X,_,X,
+	_,X,X,X,_
+};
+
+uint32_t CLOCK_1_6[] = {
+	_,X,_,X,_,
+	_,X,X,X,_,
+	_,_,_,X,_,
+	_,_,_,X,_,
+	_,_,_,X,_
+};
+
+uint32_t CLOCK_1_7[] = {
+	X,_,_,_,X,
+	X,_,_,_,X,
+	_,X,_,X,_,
+	_,X,_,X,_,
+	_,_,X,_,_
+
+};
+
+uint32_t CLOCK_1_8[] = {
+	_,_,X,_,_,
+	_,X,_,X,_,
+	_,X,_,X,_,
+	X,_,_,_,X,
+	X,_,_,_,X
+};
+
+uint32_t CLOCK_1_9[] = {
+	_,X,X,X,_,
+	_,X,_,X,_,
+	_,X,X,X,_,
+	_,_,_,X,_,
+	_,_,_,X,_
+};
+
+uint32_t CLOCK_1_S[] = {
+	_,_,_,_,_,
+	_,_,X,_,_,
+	_,_,_,_,_,
+	_,_,X,_,_,
+	_,_,_,_,_
+};
+
+uint32_t CLOCK_1_E[] = {
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_,
+	_,_,_,_,_
+};
+
 #endif
 
 #undef X
 #undef _
 
-static inline uint32_t* CLOCK_N(char c)
+static inline uint32_t* CLOCK_N(uint8_t bigclock_lang, char c)
 {
+	if (bigclock_lang == 1) {
+		switch(c)
+		{
+			case '0':
+				return CLOCK_1_0;
+			case '1':
+				return CLOCK_1_1;
+			case '2':
+				return CLOCK_1_2;
+			case '3':
+				return CLOCK_1_3;
+			case '4':
+				return CLOCK_1_4;
+			case '5':
+				return CLOCK_1_5;
+			case '6':
+				return CLOCK_1_6;
+			case '7':
+				return CLOCK_1_7;
+			case '8':
+				return CLOCK_1_8;
+			case '9':
+				return CLOCK_1_9;
+			case ':':
+				return CLOCK_1_S;
+			default:
+				return CLOCK_1_E;
+		}
+	}
 	switch(c)
 	{
 		case '0':

--- a/src/config.c
+++ b/src/config.c
@@ -162,6 +162,7 @@ void config_load(const char *cfg_path)
 		{"asterisk", &config.asterisk, config_handle_char},
 		{"bg", &config.bg, config_handle_u8},
 		{"bigclock", &config.bigclock, config_handle_bool},
+		{"bigclock_lang", &config.bigclock_lang, config_handle_u8},
 		{"blank_box", &config.blank_box, config_handle_bool},
 		{"blank_password", &config.blank_password, config_handle_bool},
 		{"clock", &config.clock, config_handle_str},
@@ -274,6 +275,7 @@ void config_defaults()
 	config.asterisk = '*';
 	config.bg = 0;
 	config.bigclock = false;
+	config.bigclock_lang = 0;
 	config.blank_box = true;
 	config.blank_password = false;
 	config.clock = NULL;

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,7 @@ struct config
 	char asterisk;
 	uint8_t bg;
 	bool bigclock;
+	uint8_t bigclock_lang;
 	bool blank_box;
 	bool blank_password;
 	char* clock;

--- a/src/draw.c
+++ b/src/draw.c
@@ -196,7 +196,7 @@ char* time_str(char* fmt, int maxlen)
 	return buffer;
 }
 
-extern inline uint32_t* CLOCK_N(char c);
+extern inline uint32_t* CLOCK_N(uint8_t bigclock_lang, char c);
 
 struct tb_cell* clock_cell(char c)
 {
@@ -208,7 +208,7 @@ struct tb_cell* clock_cell(char c)
     {
         c = ' ';
     }
-	uint32_t* clockchars = CLOCK_N(c);
+	uint32_t* clockchars = CLOCK_N(config.bigclock_lang, c);
 
 	for (int i = 0; i < CLOCK_W * CLOCK_H; i++)
 	{


### PR DESCRIPTION
### New `config.ini` item `bigclock_lang`

- is `uint8` ( for may other people want to add their languages in future)
- default value is 0 ( english )

### Screenshot :
( 14:23 -> ۱۴:۲۳ )
![Screenshot from running `ly` with Farsi big digits](https://github.com/fairyglade/ly/assets/91016770/f00e89d7-511b-45d5-86fe-b01eeda5de39)