### PR TITLE
Do not force LANG env var on login

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -220,11 +220,6 @@ void env_init(struct passwd* pwd)
 	setenv("SHELL", pwd->pw_shell, 1);
 	setenv("USER", pwd->pw_name, 1);
 	setenv("LOGNAME", pwd->pw_name, 1);
-
-	if (lang)
-	{
-		setenv("LANG", lang, 1);
-	}
 	
 	// Set PATH if specified in the configuration
 	if (strlen(config.path))

--- a/src/login.c
+++ b/src/login.c
@@ -220,8 +220,12 @@ void env_init(struct passwd* pwd)
 	setenv("SHELL", pwd->pw_shell, 1);
 	setenv("USER", pwd->pw_name, 1);
 	setenv("LOGNAME", pwd->pw_name, 1);
-	setenv("LANG", lang ? lang : "C", 1);
 
+	if (lang)
+	{
+		setenv("LANG", lang, 1);
+	}
+	
 	// Set PATH if specified in the configuration
 	if (strlen(config.path))
 	{


### PR DESCRIPTION
Regarding issue #278 
Is there any reason we have to set the LANG env var? 
At least on arch systems this causes the custom LC_* configs form /etc/locale.conf to not be applied (/etc/profile.d/locale.sh `if [ -z "$LANG" ]; then`)