### PR TITLE
Fix for XDG Portal expecting XDG_CURRENT_DESKTOP to be set

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -261,6 +261,7 @@ void env_xdg(const char* tty_id, const char* desktop_name)
 {
     char user[20];
     snprintf(user, 20, "/run/user/%d", getuid());
+    setenv("XDG_CURRENT_DESKTOP", desktop_name, 0);
     setenv("XDG_RUNTIME_DIR", user, 0);
     setenv("XDG_SESSION_CLASS", "user", 0);
     setenv("XDG_SESSION_ID", "1", 0);


### PR DESCRIPTION
This pull request fixes issue #584.