### PR TITLE
[Zig Rewrite] Update zigini

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "122014e73fd712190e109950837b97f6143f02d7e2b6986e1db70b6f4aadb5ba6a0d",
         },
         .zigini = .{
-            .url = "https://github.com/Kawaii-Ash/zigini/archive/a5b5caf43f0a0246a242df4aebd00a0649deebad.tar.gz",
-            .hash = "12202e097a54cbb7c002a2a5b3a3435939fa3902cd14308b7b66ab710e3d88d76e94",
+            .url = "https://github.com/Kawaii-Ash/zigini/archive/2f598085c8bd8b1acef1add90d116c8dd1895b45.tar.gz",
+            .hash = "12206dc36227c010c879b59ab563512f718ce4cabe570968587a0bbbcde708f64528",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Setting `asterisk` will now work as expected. An error would previously occur which caused the default config to be used. 
Should fix the configuration issue noted in #602