### PR TITLE
fix systemd stderr logging

### DIFF
--- a/res/ly.service
+++ b/res/ly.service
@@ -7,6 +7,7 @@ Conflicts=getty@tty2.service
 [Service]
 Type=idle
 ExecStart=/usr/bin/ly
+StandardError=journal
 StandardInput=tty
 TTYPath=/dev/tty2
 TTYReset=yes


### PR DESCRIPTION
None of the stderr logs were going to systemd originally. This redirects the stderr to systemd so that you can use `journalctl` or `systemctl status` to view the ly logs.