### PR TITLE
Support for Multiple TTYs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -111,7 +111,7 @@ fn installsystemd(self: *std.Build.Step, progress: *std.Progress.Node) !void {
     var service_dir = std.fs.openDirAbsolute("/usr/lib/systemd/system", .{}) catch unreachable;
     defer service_dir.close();
 
-    try std.fs.cwd().copyFile("res/ly.service", service_dir, "ly.service", .{ .override_mode = 644 });
+    try std.fs.cwd().copyFile("res/ly@.service", service_dir, "ly@.service", .{ .override_mode = 644 });
 }
 
 fn installopenrc(self: *std.Build.Step, progress: *std.Progress.Node) !void {

--- a/readme.md
+++ b/readme.md
@@ -92,9 +92,10 @@ Install Ly and the provided systemd service file
 # zig build installsystemd
 ```
 
-Enable the service
+Enable the service (this will spawn on tty2 and tty9)
 ```
-# systemctl enable ly.service
+# systemctl enable ly@tty2.service
+# systemctl enable ly@tty9.service
 ```
 
 If you need to switch between ttys after Ly's start you also have to
@@ -102,6 +103,8 @@ disable getty on Ly's tty to prevent "login" from spawning on top of it
 ```
 # systemctl disable getty@tty2.service
 ```
+
+If you have multiple ttys setup with systemd, the tty option will be used as your default tty.
 
 ### OpenRC
 **NOTE**: On Gentoo, Ly will disable the `display-manager-init` service in order to run.

--- a/res/ly@.service
+++ b/res/ly@.service
@@ -1,17 +1,18 @@
 [Unit]
-Description=TUI display manager
+Description=TUI display manager (on %I)
 After=systemd-user-sessions.service plymouth-quit-wait.service
-After=getty@tty2.service
-Conflicts=getty@tty2.service
+After=getty@%I.service
+Conflicts=getty@%I.service
 
 [Service]
 Type=idle
 ExecStart=/usr/bin/ly
 StandardError=journal
 StandardInput=tty
-TTYPath=/dev/tty2
+TTYPath=/dev/%I
 TTYReset=yes
 TTYVHangup=yes
 
 [Install]
-Alias=display-manager.service
+WantedBy=multi-user.target
+# Alias=display-manager.service

--- a/src/interop.zig
+++ b/src/interop.zig
@@ -6,6 +6,10 @@ pub const termbox = @cImport({
     @cInclude("termbox.h");
 });
 
+pub const vt = @cImport({
+    @cInclude("linux/vt.h");
+});
+
 pub const pam = @cImport({
     @cInclude("security/pam_appl.h");
 });
@@ -44,6 +48,7 @@ pub const passwd = extern struct {
     pw_shell: [*:0]u8,
 };
 
+pub const VT_GETSTATE: c_int = 0x5603;
 pub const VT_ACTIVATE: c_int = 0x5606;
 pub const VT_WAITACTIVE: c_int = 0x5607;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -526,6 +526,11 @@ pub fn main() !void {
                 defer shared_err.deinit();
 
                 {
+                    // This will set the current active VT as our TTY.
+                    var vtstat: interop.vt.vt_stat = undefined;
+                    _ = std.c.ioctl(std.c.STDIN_FILENO, interop.VT_GETSTATE, &vtstat);
+                    config.tty = @intCast(vtstat.v_active);
+
                     const login_text = try allocator.dupeZ(u8, login.text.items);
                     defer allocator.free(login_text);
                     const password_text = try allocator.dupeZ(u8, password.text.items);


### PR DESCRIPTION
This allows for Ly to run on multiple ttys concurrently. It utilizes [systemd templates](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html) to support multiple instances. It also will dynamically change the tty, allowing for the desktop environment to start up correctly.

Not sure if this is exactly what we being looked for in #532 but it is a solution that is fairly simple.