### PR TITLE
fix failure to build on zig 0.13

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -507,7 +507,7 @@ pub fn main() !void {
                         break :brightness_change;
                     };
                     defer allocator.free(brightness_str);
-                    var brightness = std.ChildProcess.init(&[_][]const u8{ config.brightnessctl, "-q", "s", brightness_str }, allocator);
+                    var brightness = std.process.Child.init(&[_][]const u8{ config.brightnessctl, "-q", "s", brightness_str }, allocator);
                     _ = brightness.spawnAndWait() catch .{};
                 } else if (pressed_key == brightness_up_key and unistd.access(&config.brightnessctl[0], unistd.X_OK) == 0) brightness_change: {
                     const brightness_str = std.fmt.allocPrint(allocator, "+{s}%", .{config.brightness_change}) catch {
@@ -515,7 +515,7 @@ pub fn main() !void {
                         break :brightness_change;
                     };
                     defer allocator.free(brightness_str);
-                    var brightness = std.ChildProcess.init(&[_][]const u8{ config.brightnessctl, "-q", "s", brightness_str }, allocator);
+                    var brightness = std.process.Child.init(&[_][]const u8{ config.brightnessctl, "-q", "s", brightness_str }, allocator);
                     _ = brightness.spawnAndWait() catch .{};
                 }
             },


### PR DESCRIPTION
zig 0.13 [renames std.ChildProcess to std.process.Child](https://ziglang.org/download/0.13.0/release-notes.html#Rename-stdChildProcess-to-stdprocessChild) this was reflected in e4abf79 (#632), but was not backported to dc8d143 (#626). consequently ly would FTBFS on zig 0.13. this commit applies the name change in all necessary places.