### PR TITLE
Prevent output of brightness/sleep command showing on screen (fixing #695)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -580,7 +580,10 @@ pub fn main() !void {
                 } else if (pressed_key == sleep_key) {
                     if (config.sleep_cmd) |sleep_cmd| {
                         var sleep = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", sleep_cmd }, allocator);
-                        _ = sleep.spawnAndWait() catch .{};
+                        sleep.stdout_behavior = .Ignore;
+                        sleep.stderr_behavior = .Ignore;
+
+                        _ = sleep.spawnAndWait() catch {};
                     }
                 } else if (pressed_key == brightness_down_key or pressed_key == brightness_up_key) {
                     const cmd = if (pressed_key == brightness_down_key) config.brightness_down_cmd else config.brightness_up_cmd;


### PR DESCRIPTION
This fixes issue #695.

For now, I only implemented the output suppression of the sleep command. Imo, it would make sense to handle the sleep command the same way as the brightness commands (aka. also showing an error message indicating the command failed). I did not implement that yet because it would require adding a lang attribute like `err_sleep` and touching every lang file (to keep consistency in the code).