### PR TITLE
added refresh interval in ms for animations

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -35,6 +35,14 @@
 # matrix -> CMatrix
 animation = none
 
+# The minimum time between animation frames
+# 32 -> ~30fps
+# 16 -> ~60fps
+# 8  -> ~120fps
+# 6  -> ~144fps
+# 4  -> ~240fps
+animation_refresh_ms = 16
+
 # Stop the animation after some time
 # 0 -> Run forever
 # 1..2e12 -> Stop the animation after this many seconds

--- a/src/animations/Doom.zig
+++ b/src/animations/Doom.zig
@@ -97,9 +97,9 @@ pub fn draw(self: Doom) void {
 }
 
 fn initBuffer(buffer: []u8, width: usize) void {
-    const length = buffer.len - width;
+    const length = buffer.len;
     const slice_start = buffer[0..length];
-    const slice_end = buffer[length..];
+    const slice_end = buffer[length - width .. length];
 
     @memset(slice_start, 0);
     @memset(slice_end, STEPS - 1);

--- a/src/animations/Doom.zig
+++ b/src/animations/Doom.zig
@@ -50,7 +50,7 @@ pub fn realloc(self: *Doom) !void {
     self.buffer = buffer;
 }
 
-pub fn draw(self: Doom) void {
+pub fn draw_with_update(self: Doom) void {
     for (0..self.terminal_buffer.width) |x| {
         for (1..self.terminal_buffer.height) |y| {
             const source = y * self.terminal_buffer.width + x;
@@ -69,6 +69,18 @@ pub fn draw(self: Doom) void {
             self.buffer[dest] = @intCast(buffer_dest);
 
             self.terminal_buffer.buffer[dest] = toTermboxCell(FIRE[buffer_dest]);
+            self.terminal_buffer.buffer[source] = toTermboxCell(FIRE[buffer_source]);
+        }
+    }
+}
+
+pub fn draw(self: Doom) void {
+    for (0..self.terminal_buffer.width) |x| {
+        for (1..self.terminal_buffer.height) |y| {
+            const source = y * self.terminal_buffer.width + x;
+
+            const buffer_source = self.buffer[source];
+
             self.terminal_buffer.buffer[source] = toTermboxCell(FIRE[buffer_source]);
         }
     }

--- a/src/animations/Doom.zig
+++ b/src/animations/Doom.zig
@@ -97,10 +97,10 @@ pub fn draw(self: Doom) void {
 }
 
 fn initBuffer(buffer: []u8, width: usize) void {
-    const length = buffer.len;
-    const slice_start = buffer[0..length];
-    const slice_end = buffer[length - width .. length];
+    const slice_start = buffer[0..buffer.len];
+    const slice_end = buffer[buffer.len - width .. buffer.len];
 
+    // set cell initial values to 0, set bottom row to be fire sources
     @memset(slice_start, 0);
     @memset(slice_end, STEPS - 1);
 }

--- a/src/animations/Doom.zig
+++ b/src/animations/Doom.zig
@@ -50,7 +50,7 @@ pub fn realloc(self: *Doom) !void {
     self.buffer = buffer;
 }
 
-pub fn draw_with_update(self: Doom) void {
+pub fn drawWithUpdate(self: Doom) void {
     for (0..self.terminal_buffer.width) |x| {
         for (1..self.terminal_buffer.height) |y| {
             // get source index

--- a/src/animations/Doom.zig
+++ b/src/animations/Doom.zig
@@ -53,21 +53,28 @@ pub fn realloc(self: *Doom) !void {
 pub fn draw_with_update(self: Doom) void {
     for (0..self.terminal_buffer.width) |x| {
         for (1..self.terminal_buffer.height) |y| {
+            // get source index
             const source = y * self.terminal_buffer.width + x;
+
+            // random number between 0 and 3 inclusive
             const random = (self.terminal_buffer.random.int(u16) % 7) & 3;
 
+            // adjust destination index based on random value
             var dest = (source - @min(source, random)) + 1;
             if (self.terminal_buffer.width > dest) dest = 0 else dest -= self.terminal_buffer.width;
 
+            // get source intensity and destination offset
             const buffer_source = self.buffer[source];
             const buffer_dest_offset = random & 1;
 
             if (buffer_source < buffer_dest_offset) continue;
 
+            // calculate  the destination intensity
             var buffer_dest = buffer_source - buffer_dest_offset;
             if (buffer_dest > 12) buffer_dest = 0;
             self.buffer[dest] = @intCast(buffer_dest);
 
+            // update terminal
             self.terminal_buffer.buffer[dest] = toTermboxCell(FIRE[buffer_dest]);
             self.terminal_buffer.buffer[source] = toTermboxCell(FIRE[buffer_source]);
         }
@@ -77,10 +84,13 @@ pub fn draw_with_update(self: Doom) void {
 pub fn draw(self: Doom) void {
     for (0..self.terminal_buffer.width) |x| {
         for (1..self.terminal_buffer.height) |y| {
+            // get source index
             const source = y * self.terminal_buffer.width + x;
 
+            // get intensity from buffer
             const buffer_source = self.buffer[source];
 
+            // set cell to correct fire char
             self.terminal_buffer.buffer[source] = toTermboxCell(FIRE[buffer_source]);
         }
     }

--- a/src/animations/Matrix.zig
+++ b/src/animations/Matrix.zig
@@ -68,7 +68,7 @@ pub fn realloc(self: *Matrix) !void {
     self.lines = lines;
 }
 
-pub fn draw_with_update(self: *Matrix) void {
+pub fn drawWithUpdate(self: *Matrix) void {
     const buf_height = self.terminal_buffer.height;
     const buf_width = self.terminal_buffer.width;
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -8,6 +8,7 @@ const Bigclock = enums.Bigclock;
 
 animation: Animation = .none,
 animation_timeout_sec: u12 = 0,
+animation_refresh_ms: u16 = 16,
 asterisk: ?u8 = '*',
 auth_fails: u64 = 10,
 bg: u16 = 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -704,9 +704,6 @@ pub fn main() !void {
                     const password_text = try allocator.dupeZ(u8, password.text.items);
                     defer allocator.free(password_text);
 
-                    // Give up control on the TTY
-                    // _ = termbox.tb_shutdown();
-
                     session_pid = try std.posix.fork();
                     if (session_pid == 0) {
                         const current_environment = session.label.list.items[session.label.current];
@@ -720,10 +717,6 @@ pub fn main() !void {
                     _ = std.posix.waitpid(session_pid, 0);
                     session_pid = -1;
                 }
-
-                // Take back control of the TTY
-                _ = termbox.tb_init();
-                _ = termbox.tb_set_output_mode(termbox.TB_OUTPUT_NORMAL);
 
                 const auth_err = shared_err.readError();
                 if (auth_err) |err| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -317,9 +317,9 @@ pub fn main() !void {
         }
     }
 
-    var animation_timer = switch(config.animation) {
+    var animation_timer = switch (config.animation) {
         .none => undefined,
-        else => try std.time.Timer.start()
+        else => try std.time.Timer.start(),
     };
 
     const animate = config.animation != .none;
@@ -344,7 +344,6 @@ pub fn main() !void {
     interop.switchTty(config.console_dev, config.tty) catch {
         try info_line.addMessage(lang.err_console_dev, config.error_bg, config.error_fg);
     };
-
 
     while (run) {
         // If there's no input or there's an animation, a resolution change needs to be checked
@@ -706,7 +705,7 @@ pub fn main() !void {
                     defer allocator.free(password_text);
 
                     // Give up control on the TTY
-                    _ = termbox.tb_shutdown();
+                    // _ = termbox.tb_shutdown();
 
                     session_pid = try std.posix.fork();
                     if (session_pid == 0) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -388,7 +388,7 @@ pub fn main() !void {
                         .doom => {
                             if (animation_timer.read() / std.time.ns_per_ms > config.animation_refresh_ms) {
                                 animation_timer.reset();
-                                doom.draw_with_update();
+                                doom.drawWithUpdate();
                             } else {
                                 doom.draw();
                             }
@@ -396,7 +396,7 @@ pub fn main() !void {
                         .matrix => {
                             if (animation_timer.read() / std.time.ns_per_ms > config.animation_refresh_ms) {
                                 animation_timer.reset();
-                                matrix.draw_with_update();
+                                matrix.drawWithUpdate();
                             } else {
                                 matrix.draw();
                             }


### PR DESCRIPTION
Added a configuration option that allows the user to set the time between animation frames in milliseconds called `animation_refresh_ms`.

Had to change around the animation code to separate updating the animation buffer and drawing to the terminal buffer a bit, and if there is an animation a new `std.time.Timer` is used to check if enough time has passed to draw with an update.

Sort of what I wanted out of #708 