### PR TITLE
fix pam_path variable assignment during build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -297,7 +297,7 @@ fn install_ly(allocator: std.mem.Allocator, install_config: bool) !void {
     }
 
     {
-        const pam_path = try std.fs.path.join(allocator, &[_][]const u8{ dest_directory, config_directory, "/pam.d" });
+        const pam_path = try std.fs.path.join(allocator, &[_][]const u8{ config_directory, "/pam.d" });
         if (!std.mem.eql(u8, dest_directory, "")) {
             std.fs.cwd().makePath(pam_path) catch {
                 std.debug.print("warn: {s} already exists as a directory.\n", .{pam_path});


### PR DESCRIPTION
It seems that the path for the PAM config file for ly gets determined differently than the other paths. This does not normally cause any problems, because prefixing an empty string to `config_directory` still results in the correct directory. But it breaks when a non-default `dest_directory` is used.

Reproduce via:
```
zig build installsystemd -Ddest_directory='/tmp/debug-ly' && find /tmp/debug-ly
```

Note the duplicated path:
```
/tmp/debug-ly
...
/tmp/debug-ly/tmp
/tmp/debug-ly/tmp/debug-ly
/tmp/debug-ly/tmp/debug-ly/etc
/tmp/debug-ly/tmp/debug-ly/etc/pam.d
/tmp/debug-ly/tmp/debug-ly/etc/pam.d/ly
```

This MR should fix that.
