### PR TITLE
Restart unit on failure or closure

### DIFF
--- a/res/ly.service
+++ b/res/ly.service
@@ -11,6 +11,7 @@ StandardInput=tty
 TTYPath=/dev/tty$DEFAULT_TTY
 TTYReset=yes
 TTYVHangup=yes
+Restart=always
 
 [Install]
 Alias=display-manager.service


### PR DESCRIPTION
When control+c is pressed in the login screen, ly closes and doesn't start back again, leaving the session stuck. This will make sure ly is running.