### PR TITLE
config: add shell option to hide the shell session

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -330,6 +330,10 @@ session_log = .local/state/ly-session.log
 # Setup command
 setup_cmd = $CONFIG_DIRECTORY/ly/setup.sh
 
+# Show the shell session in the session list
+# If false, the shell session will be hidden
+shell = true
+
 # Specifies the key combination used for showing the password
 show_password_key = F7
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -80,6 +80,7 @@ path: ?[]const u8 = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bi
 restart_cmd: []const u8 = "/sbin/shutdown -r now",
 restart_key: []const u8 = "F2",
 save: bool = true,
+shell: bool = true,
 service_name: [:0]const u8 = "ly",
 session_log: ?[]const u8 = "ly-session.log",
 setup_cmd: []const u8 = build_options.config_directory ++ "/ly/setup.sh",

--- a/src/main.zig
+++ b/src/main.zig
@@ -725,18 +725,20 @@ pub fn main() !void {
     try state.buffer.registerKeybind(&state.login.label.keybinds, "H", &viGoLeft, &state);
     try state.buffer.registerKeybind(&state.login.label.keybinds, "L", &viGoRight, &state);
 
-    addOtherEnvironment(&state.session, state.lang, .shell, null) catch |err| {
-        try state.info_line.addMessage(
-            state.lang.err_alloc,
-            state.config.error_bg,
-            state.config.error_fg,
-        );
-        try state.log_file.err(
-            "sys",
-            "failed to add shell environment: {s}",
-            .{@errorName(err)},
-        );
-    };
+    if (state.config.shell) {
+        addOtherEnvironment(&state.session, state.lang, .shell, null) catch |err| {
+            try state.info_line.addMessage(
+                state.lang.err_alloc,
+                state.config.error_bg,
+                state.config.error_fg,
+            );
+            try state.log_file.err(
+                "sys",
+                "failed to add shell environment: {s}",
+                .{@errorName(err)},
+            );
+        };
+    }
 
     if (build_options.enable_x11_support) {
         if (state.config.xinitrc) |xinitrc_cmd| {


### PR DESCRIPTION
## Description

The shell session is unconditionally added to the session list with no way to
hide it. This is inconsistent with `xinitrc`, which is omitted from the list
when set to `null`.

This change adds a `shell` boolean config option (default `true`). Setting it
to `false` hides the shell session from the list, following the same pattern
as `xinitrc`.